### PR TITLE
feat(authorization): adiciona o authorizator para controladores em app

### DIFF
--- a/src/app/v1/selection-service/current-selection/route.js
+++ b/src/app/v1/selection-service/current-selection/route.js
@@ -1,10 +1,11 @@
-import { NextResponse } from "next/server";
-
+import authorizator from "src/services/auth/authorizator";
 import selectionQueryService from "src/services/selection/query";
 import controller from "utils/controller";
 
 export async function GET(request) {
   try {
+    await authorizator.token().can("GET:CURRENT_SELECTION");
+
     const currentSelection = await selectionQueryService.getCurrentSelection();
 
     return controller.response.ok(200, {

--- a/src/app/v1/selection-service/features.js
+++ b/src/app/v1/selection-service/features.js
@@ -1,0 +1,19 @@
+export default Object.freeze({
+  "GET:CURRENT_SELECTION": {
+    allowUnauthenticated: true,
+    verifier: (session, resource) => true,
+  },
+
+  "POST:APPLICATION": {
+    allowUnauthenticated: false,
+    verifier: (session, resource) => {
+      if (
+        session.email &&
+        resource?.email &&
+        resource?.email === session.email
+      ) {
+        return true;
+      }
+    },
+  },
+});

--- a/src/services/auth/authorizator.js
+++ b/src/services/auth/authorizator.js
@@ -1,0 +1,48 @@
+import jwt from "jsonwebtoken";
+
+import selectionFeatures from "src/app/v1/selection-service/features";
+import { ForbiddenError, UnauthorizedError } from "utils/errors";
+
+const features = {
+  ...selectionFeatures,
+};
+
+function token(token) {
+  let session;
+
+  if (token) {
+    try {
+      session = jwt.verify(token, process.env.JWT_SIGNER_KEY);
+    } catch (error) {
+      throw new UnauthorizedError({
+        message: "Você está tentando usar um token inválido.",
+      });
+    }
+  } else {
+    session = { role: "unauthenticated" };
+  }
+
+  async function can(featureTitle, options) {
+    const { allowUnauthenticated, verifier } = features[featureTitle];
+
+    if (!allowUnauthenticated && session.role === "unauthenticated") {
+      throw new UnauthorizedError({});
+    }
+
+    const passed = await verifier(session, options?.resource);
+
+    if (!passed) {
+      throw new ForbiddenError({});
+    }
+
+    return;
+  }
+
+  return {
+    can,
+  };
+}
+
+export default Object.freeze({
+  token,
+});


### PR DESCRIPTION
adiciona features para cada grupo de rotas dentro de cada serviço (na pasta app) e adiciona um modulo `authorizator` que pega o token do usuário, interpreta a sessão e executa as funções de verificação de cada feature.

#28 
#25 